### PR TITLE
DL-293 fixing versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ mapr_installation CHANGELOG
 
 This file is used to list changes made in each version of the mapr_installation cookbook.
 
-0.3.4
+0.3.6
 -----
 - [eric moritz] - DL-293 bumped default version to 4.1.x
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'emoritz@gannett.com'
 license          'All rights reserved'
 description      'Installs/Configures mapr_installation'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.5'
+version          '0.3.6'
 
 depends 'selinux'
 depends 'ntp'


### PR DESCRIPTION
This branch bumps up the version of MapR to 2.1 and advances the mapr_installation version because I didn't do things properly